### PR TITLE
minor enhancement: make ```_storedERC721Ids``` internal

### DIFF
--- a/contracts/ERC404.sol
+++ b/contracts/ERC404.sol
@@ -12,7 +12,7 @@ abstract contract ERC404 is IERC404 {
   using DoubleEndedQueue for DoubleEndedQueue.Uint256Deque;
 
   /// @dev The queue of ERC-721 tokens stored in the contract.
-  DoubleEndedQueue.Uint256Deque private _storedERC721Ids;
+  DoubleEndedQueue.Uint256Deque internal _storedERC721Ids;
 
   /// @dev Token name
   string public name;

--- a/contracts/ERC404U16.sol
+++ b/contracts/ERC404U16.sol
@@ -14,7 +14,7 @@ abstract contract ERC404U16 is IERC404 {
   using PackedDoubleEndedQueue for PackedDoubleEndedQueue.Uint16Deque;
 
   /// @dev The queue of ERC-721 tokens stored in the contract.
-  PackedDoubleEndedQueue.Uint16Deque private _storedERC721Ids;
+  PackedDoubleEndedQueue.Uint16Deque internal _storedERC721Ids;
 
   /// @dev Token name
   string public name;


### PR DESCRIPTION
## Motivation
This pull request is for addressing [this issue](https://github.com/Pandora-Labs-Org/erc404/issues/26).

The change makes it easier for developers to build features by accessing variable ```_storedERC721Ids```  as part of an inherited contract.

## Change Summary

The change in this PR switches ```_storedERC721Ids``` access modifier from ```private``` to ```internal```.