### PR TITLE
feat: Add getReadableTokenId function to ERC404 interfaces

### DIFF
--- a/contracts/ERC404.sol
+++ b/contracts/ERC404.sol
@@ -818,4 +818,11 @@ abstract contract ERC404 is IERC404 {
 
     _ownedData[id_] = data;
   }
+
+  function getReadebleTokenId(uint256 id_) public pure returns (uint256) {
+    if (_isValidTokenId(id_)) {
+      return id - ID_ENCODING_PREFIX;
+    }
+    revert InvalidTokenId();
+  }
 }

--- a/contracts/ERC404.sol
+++ b/contracts/ERC404.sol
@@ -819,7 +819,7 @@ abstract contract ERC404 is IERC404 {
     _ownedData[id_] = data;
   }
 
-  function getReadebleTokenId(uint256 id_) public pure returns (uint256) {
+  function getReadableTokenId(uint256 id_) public pure returns (uint256) {
     if (_isValidTokenId(id_)) {
       return id - ID_ENCODING_PREFIX;
     }

--- a/contracts/ERC404U16.sol
+++ b/contracts/ERC404U16.sol
@@ -815,7 +815,7 @@ abstract contract ERC404U16 is IERC404 {
     _ownedData[id_] = data;
   }
 
-  function getReadebleTokenId(uint256 id_) public pure returns (uint256) {
+  function getReadableTokenId(uint256 id_) public pure returns (uint256) {
     if (_isValidTokenId(id_)) {
       return id - ID_ENCODING_PREFIX;
     }

--- a/contracts/ERC404U16.sol
+++ b/contracts/ERC404U16.sol
@@ -814,4 +814,11 @@ abstract contract ERC404U16 is IERC404 {
 
     _ownedData[id_] = data;
   }
+
+  function getReadebleTokenId(uint256 id_) public pure returns (uint256) {
+    if (_isValidTokenId(id_)) {
+      return id - ID_ENCODING_PREFIX;
+    }
+    revert InvalidTokenId();
+  }
 }

--- a/contracts/interfaces/IERC404.sol
+++ b/contracts/interfaces/IERC404.sol
@@ -89,5 +89,5 @@ interface IERC404 is IERC165 {
     bytes32 r_,
     bytes32 s_
   ) external;
-  function getReadebleTokenId(uint256 id_) public pure returns (uint256);
+  function getReadableTokenId(uint256 id_) public pure returns (uint256);
 }

--- a/contracts/interfaces/IERC404.sol
+++ b/contracts/interfaces/IERC404.sol
@@ -89,4 +89,5 @@ interface IERC404 is IERC165 {
     bytes32 r_,
     bytes32 s_
   ) external;
+  function getReadebleTokenId(uint256 id_) public pure returns (uint256);
 }


### PR DESCRIPTION
- make it easier for on chain contracts to show the "actual" token id in the token URI 
![image](https://github.com/Pandora-Labs-Org/erc404/assets/3748658/848de8f3-f60b-44f7-a2f3-319f181da71c)

- make it easier for holders to search on marketplaces, but does not fix the url in marketplaces.