### PR TITLE
Make decimal as constant as WEI

### DIFF
--- a/contracts/ERC404.sol
+++ b/contracts/ERC404.sol
@@ -20,9 +20,6 @@ abstract contract ERC404 is IERC404 {
   /// @dev Token symbol
   string public symbol;
 
-  /// @dev Decimals for ERC-20 representation
-  uint8 public immutable decimals;
-
   /// @dev Units for ERC-20 representation
   uint256 public immutable units;
 
@@ -72,15 +69,13 @@ abstract contract ERC404 is IERC404 {
   /// @dev Constant for token id encoding
   uint256 public constant ID_ENCODING_PREFIX = 1 << 255;
 
-  constructor(string memory name_, string memory symbol_, uint8 decimals_) {
+  /// @dev Decimals for ERC-20 representation
+  uint8 public constant decimals = 18;
+
+  constructor(string memory name_, string memory symbol_) {
     name = name_;
     symbol = symbol_;
 
-    if (decimals_ < 18) {
-      revert DecimalsTooLow();
-    }
-
-    decimals = decimals_;
     units = 10 ** decimals;
 
     // EIP-2612 initialization

--- a/contracts/ERC404U16.sol
+++ b/contracts/ERC404U16.sol
@@ -22,9 +22,6 @@ abstract contract ERC404U16 is IERC404 {
   /// @dev Token symbol
   string public symbol;
 
-  /// @dev Decimals for ERC-20 representation
-  uint8 public immutable decimals;
-
   /// @dev Units for ERC-20 representation
   uint256 public immutable units;
 
@@ -74,15 +71,13 @@ abstract contract ERC404U16 is IERC404 {
   /// @dev Constant for token id encoding
   uint256 public constant ID_ENCODING_PREFIX = 1 << 255;
 
-  constructor(string memory name_, string memory symbol_, uint8 decimals_) {
+  /// @dev Decimals for ERC-20 representation
+  uint8 public constant decimals = 18;
+
+  constructor(string memory name_, string memory symbol_) {
     name = name_;
     symbol = symbol_;
 
-    if (decimals_ < 18) {
-      revert DecimalsTooLow();
-    }
-
-    decimals = decimals_;
     units = 10 ** decimals;
 
     // EIP-2612 initialization

--- a/contracts/examples/ERC404Example.sol
+++ b/contracts/examples/ERC404Example.sol
@@ -9,11 +9,10 @@ contract ERC404Example is Ownable, ERC404 {
   constructor(
     string memory name_,
     string memory symbol_,
-    uint8 decimals_,
     uint256 maxTotalSupplyERC721_,
     address initialOwner_,
     address initialMintRecipient_
-  ) ERC404(name_, symbol_, decimals_) Ownable(initialOwner_) {
+  ) ERC404(name_, symbol_) Ownable(initialOwner_) {
     // Do not mint the ERC721s to the initial owner, as it's a waste of gas.
     _setERC721TransferExempt(initialMintRecipient_, true);
     _mintERC20(initialMintRecipient_, maxTotalSupplyERC721_ * units);

--- a/contracts/examples/ERC404ExampleU16.sol
+++ b/contracts/examples/ERC404ExampleU16.sol
@@ -9,11 +9,10 @@ contract ERC404ExampleU16 is Ownable, ERC404U16 {
   constructor(
     string memory name_,
     string memory symbol_,
-    uint8 decimals_,
     uint256 maxTotalSupplyERC721_,
     address initialOwner_,
     address initialMintRecipient_
-  ) ERC404U16(name_, symbol_, decimals_) Ownable(initialOwner_) {
+  ) ERC404U16(name_, symbol_) Ownable(initialOwner_) {
     // Do not mint the ERC721s to the initial owner, as it's a waste of gas.
     _setERC721TransferExempt(initialMintRecipient_, true);
     _mintERC20(initialMintRecipient_, maxTotalSupplyERC721_ * units);

--- a/contracts/examples/ERC404ExampleUniswapV2.sol
+++ b/contracts/examples/ERC404ExampleUniswapV2.sol
@@ -10,13 +10,12 @@ contract ERC404ExampleUniswapV2 is Ownable, ERC404, ERC404UniswapV2Exempt {
   constructor(
     string memory name_,
     string memory symbol_,
-    uint8 decimals_,
     uint256 maxTotalSupplyERC721_,
     address initialOwner_,
     address initialMintRecipient_,
     address uniswapV2Router_
   )
-    ERC404(name_, symbol_, decimals_)
+    ERC404(name_, symbol_)
     Ownable(initialOwner_)
     ERC404UniswapV2Exempt(uniswapV2Router_)
   {

--- a/contracts/examples/ERC404ExampleUniswapV3.sol
+++ b/contracts/examples/ERC404ExampleUniswapV3.sol
@@ -10,14 +10,13 @@ contract ERC404ExampleUniswapV3 is Ownable, ERC404, ERC404UniswapV3Exempt {
   constructor(
     string memory name_,
     string memory symbol_,
-    uint8 decimals_,
     uint256 maxTotalSupplyERC721_,
     address initialOwner_,
     address initialMintRecipient_,
     address uniswapSwapRouter_,
     address uniswapV3NonfungiblePositionManager_
   )
-    ERC404(name_, symbol_, decimals_)
+    ERC404(name_, symbol_)
     Ownable(initialOwner_)
     ERC404UniswapV3Exempt(
       uniswapSwapRouter_,

--- a/contracts/interfaces/IERC404.sol
+++ b/contracts/interfaces/IERC404.sol
@@ -15,7 +15,6 @@ interface IERC404 is IERC165 {
   error RecipientIsERC721TransferExempt();
   error Unauthorized();
   error InsufficientAllowance();
-  error DecimalsTooLow();
   error PermitDeadlineExpired();
   error InvalidSigner();
   error InvalidApproval();

--- a/contracts/mocks/MinimalERC404.sol
+++ b/contracts/mocks/MinimalERC404.sol
@@ -9,9 +9,8 @@ contract MinimalERC404 is Ownable, ERC404 {
   constructor(
     string memory name_,
     string memory symbol_,
-    uint8 decimals_,
     address initialOwner_
-  ) ERC404(name_, symbol_, decimals_) Ownable(initialOwner_) {}
+  ) ERC404(name_, symbol_) Ownable(initialOwner_) {}
 
   function mintERC20(address account_, uint256 value_) external onlyOwner {
     _mintERC20(account_, value_);

--- a/scripts/gas-test.ts
+++ b/scripts/gas-test.ts
@@ -19,7 +19,6 @@ async function main() {
   const erc404V2Contract = await erc404V2Factory.deploy(
     "ERC404Example",
     "ERC404",
-    18,
     500,
     signers[0].address,
     signers[0].address,
@@ -33,7 +32,6 @@ async function main() {
   const erc404U16V2Contract = await erc404U16V2Factory.deploy(
     "ERC404ExampleU16",
     "ERC404U16",
-    18,
     500,
     signers[0].address,
     signers[0].address,

--- a/test/ERC404.t.ts
+++ b/test/ERC404.t.ts
@@ -21,7 +21,6 @@ describe("ERC404", function () {
     const contract = await factory.deploy(
       name,
       symbol,
-      decimals,
       maxTotalSupplyERC721,
       initialOwner.address,
       initialMintRecipient.address,
@@ -147,7 +146,6 @@ describe("ERC404", function () {
     const contract = await factory.deploy(
       name,
       symbol,
-      decimals,
       initialOwner.address,
     )
     await contract.waitForDeployment()

--- a/test/ERC404UniswapV2Exempt.t.ts
+++ b/test/ERC404UniswapV2Exempt.t.ts
@@ -52,7 +52,6 @@ describe("ERC404UniswapV2Exempt", function () {
     const contract = await factory.deploy(
       name,
       symbol,
-      decimals,
       maxTotalSupplyERC721,
       initialOwner.address,
       initialMintRecipient.address,

--- a/test/ERC404UniswapV3Exempt.t.ts
+++ b/test/ERC404UniswapV3Exempt.t.ts
@@ -70,7 +70,6 @@ describe("ERC404UniswapV3Exempt", function () {
     const contract = await factory.deploy(
       name,
       symbol,
-      decimals,
       maxTotalSupplyERC721,
       initialOwner.address,
       initialMintRecipient.address,


### PR DESCRIPTION
Due to the majority of deployed tokens using WEI decimals (standard from Openzeppelin), I have made a little improvement in this part.